### PR TITLE
Remove Qt5 Support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,8 @@ on:
       'v*'
   pull_request:
     branches: [ main ]
-
+env:
+    QT_VERSION: 6.3.0
 jobs:
   # This is a super hacky way to get this into a place that can actually be
   # used by downstream jobs because YAML values don't allow shell
@@ -49,32 +50,24 @@ jobs:
       matrix:
         config:
         - {
-         name: "Linux-Qt5"
-            , os: ubuntu-18.04
-            , QT_VERSION: 5.15.2 , QT_INST_DIR: /opt
-            , QT_STRING: "-Qt5"
-            , extraCMakeConfig: "-DCMAKE_INSTALL_PREFIX=/usr -DQT_DEFAULT_MAJOR_VERSION=5"
-          }
-        - {
-            name: "Linux-Qt6"
+            name: "Linux"
             , os: ubuntu-20.04
-            , QT_VERSION: 6.3.0, QT_INST_DIR: /opt
-            , QT_STRING: "-Qt6"
+            , QT_INST_DIR: /opt
             , extraCMakeConfig: "-DCMAKE_INSTALL_PREFIX=/usr"
-            , linuxDeployQtPath: "export PATH=$PATH:/opt/Qt/6.3.0/gcc_64/libexec"
+            , linuxDeployQtPath:
           }
         - {
-            name: "Mac-Qt6"
+            name: "Mac"
             , os: macos-latest
-            , QT_VERSION: 6.3.0, QT_INST_DIR: /Users/runner
+            , QT_INST_DIR: /Users/runner
             , extraCMakeConfig: "-DCMAKE_OSX_ARCHITECTURES=\"arm64;x86_64\""
             , cmakeSigning: "-DNOTARIZE_AS=\"John Kennedy\""
             , buildTarget: "--target package"
           }
         - {
-            name: "Windows-Qt6", WIN_ARCH: "x64"
+            name: "Windows", WIN_ARCH: "x64"
             , os: windows-2019
-            , QT_VERSION: 6.3.0, QT_INST_DIR: "C:/", QTDIR: "C:/Qt/6.3.0/msvc2019_64", QT_ARCH: win64_msvc2019_64
+            , QT_INST_DIR: "C:/", QT_ARCH: win64_msvc2019_64
             , extraCMakeConfig: "-G Ninja"
             , buildTarget: "--target package"
           }
@@ -82,7 +75,7 @@ jobs:
     - name: Setup env
       shell: bash
       run: |
-        echo "name=ashirt-${{ needs.run-info.outputs.sha8 }}${{matrix.config.QT_STRING}}" >> $GITHUB_ENV
+        echo "name=ashirt-${{ needs.run-info.outputs.sha8 }}" >> $GITHUB_ENV
         echo "githash=${{ needs.run-info.outputs.sha8 }}" >> $GITHUB_ENV
         echo "signRelease=${{ needs.run-info.outputs.signRelease }}" >> $GITHUB_ENV
 
@@ -98,7 +91,7 @@ jobs:
       uses: actions/cache@v3.0.2
       with:
         path: ${{matrix.config.QT_INST_DIR}}/Qt
-        key: ${{ runner.os }}${{ matrix.config.WIN_ARCH }}-qt-${{ matrix.config.QT_VERSION }}
+        key: ${{ runner.os }}${{ matrix.config.WIN_ARCH }}-qt-${{ env.QT_VERSION }}
 
     - name: Env Script (Windows)
       uses: ilammy/msvc-dev-cmd@v1
@@ -120,7 +113,7 @@ jobs:
        py7zrversion: ==0.16.2
        dir: ${{matrix.config.QT_INST_DIR}}
        arch: ${{ matrix.config.QT_ARCH }}
-       version: ${{ matrix.config.QT_VERSION }}
+       version: ${{ env.QT_VERSION }}
        cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
     - name: Install Dependencies
@@ -146,8 +139,8 @@ jobs:
             wget -qc "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
             wget -qc "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
             chmod a+x linuxdeploy*.AppImage
-            export VERSION=${{ env.githash }}${{ matrix.config.QT_STRING }}
-            ${{matrix.config.linuxDeployQtPath}}
+            export VERSION=${{ env.githash }}
+            export PATH=$PATH:/opt/Qt/${{env.QT_VERSION}}/gcc_64/libexec
             ./linuxdeploy-x86_64.AppImage --appdir=appdir  --output appimage \
                 -e src/ashirt \
                 -d deploy/ashirt.desktop \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,12 +128,14 @@ jobs:
     - name: Build
       shell: bash
       run: |
+        echo CMAKE_OPTIONS=
         if [[ "${{ env.signRelease }}" == "true" ]]; then
-            cmake -DCMAKE_BUILD_TYPE=Release -DCPACK_PACKAGE_VERSION=${{env.githash}} ${{matrix.config.extraCMakeConfig}} ${{matrix.config.cmakeSigning}}
+            cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCPACK_PACKAGE_VERSION=${{env.githash}} ${{matrix.config.extraCMakeConfig}} ${{matrix.config.cmakeSigning}}
         else
-            cmake -DCMAKE_BUILD_TYPE=Release -DCPACK_PACKAGE_VERSION=${{env.githash}} ${{matrix.config.extraCMakeConfig}}
+            cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCPACK_PACKAGE_VERSION=${{env.githash}} ${{matrix.config.extraCMakeConfig}}
         fi
-        cmake --build . ${{ matrix.config.buildTarget }}
+        cmake --build build ${{ matrix.config.buildTarget }}
+        cd build
         mkdir -p dist
         if [ "$RUNNER_OS" == "Linux" ]; then
             wget -qc "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
@@ -143,8 +145,8 @@ jobs:
             export PATH=$PATH:/opt/Qt/${{env.QT_VERSION}}/gcc_64/libexec
             ./linuxdeploy-x86_64.AppImage --appdir=appdir  --output appimage \
                 -e src/ashirt \
-                -d deploy/ashirt.desktop \
-                -i deploy/hicolor/128x128/apps/ashirt.png \
+                -d ../deploy/ashirt.desktop \
+                -i ../deploy/hicolor/128x128/apps/ashirt.png \
                 --plugin=qt
         elif [[ "$RUNNER_OS" == "macOS" && "${{ env.signRelease }}" == "true" ]]; then
             brew tap mitchellh/gon
@@ -159,7 +161,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: ashirt-${{env.githash}}
-        path: dist/ashirt-*.*
+        path: build/dist/ashirt-*.*
 
   release:
     name: Release
@@ -177,7 +179,7 @@ jobs:
        automatic_release_tag: "continuous"
        prerelease: false
        title: "Continuous Build"
-       files: dist/ashirt-*.*
+       files: build/dist/ashirt-*.*
 
     - name: Deploy Tag
       if: needs.run-info.outputs.isRelease == 'true'
@@ -187,4 +189,4 @@ jobs:
        automatic_release_tag: ${{ github.ref }}
        prerelease: false
        title: ${{ github.ref }}
-       files: dist/ashirt-*.*
+       files: build/dist/ashirt-*.*

--- a/deploy/CMakeLists.txt
+++ b/deploy/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 
 if(WIN32)
+    configure_file(ashirt.rc.in ${CMAKE_CURRENT_BINARY_DIR}/ashirt.rc @ONLY)
     install(FILES ${CMAKE_SOURCE_DIR}/LICENSE DESTINATION . RENAME LICENSE.txt)
     install(FILES ${CMAKE_SOURCE_DIR}/README.md DESTINATION . RENAME README.txt)
 elseif(APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,7 @@ if(APPLE)
     set_source_files_properties(${ASHIRT_PLATFORM_EX_SRC} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 elseif(WIN32)
     set(CMAKE_PREFIX_PATH $ENV{QTDIR})
-    configure_file(${CMAKE_SOURCE_DIR}/deploy/ashirt.rc.in ${CMAKE_BINARY_DIR}/deploy/ashirt.rc @ONLY)
+    include_directories(${CMAKE_SOURCE_DIR}/deploy)
     set(ASHIRT_PLATFORM_EX_SRC ${CMAKE_BINARY_DIR}/deploy/ashirt.rc)
 endif()
 

--- a/src/components/tagging/tagwidget.cpp
+++ b/src/components/tagging/tagwidget.cpp
@@ -24,13 +24,9 @@ void TagWidget::setReadOnly(bool readonly) {
 }
 
 void TagWidget::mouseReleaseEvent(QMouseEvent* evt) {
-#if(QT_VERSION_MAJOR > 5)
   const int x = evt->position().x();
   const int y = evt->position().y();
-#else
-    const int x = evt->x();
-    const int y = evt->y();
-#endif
+
   if (removeArea.contains(x, y)) {
     emit removePressed();
   }

--- a/src/helpers/hotkeys/uglobalhotkeys.h
+++ b/src/helpers/hotkeys/uglobalhotkeys.h
@@ -42,10 +42,8 @@ public:
     void onHotkeyPressed(size_t id);
 #endif
 
-#if (defined (Q_OS_WIN) || defined (Q_OS_LINUX)) && QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+#if (defined (Q_OS_WIN) || defined (Q_OS_LINUX))
     typedef qintptr RESULT_TYPE;
-#elif defined (Q_OS_WIN) || defined (Q_OS_LINUX)
-    typedef long RESULT_TYPE;
 #endif
 
 protected:

--- a/src/helpers/hotkeys/ukeysequence.cpp
+++ b/src/helpers/hotkeys/ukeysequence.cpp
@@ -105,11 +105,7 @@ void UKeySequence::addKey(const QString &key)
         return;
     }
 
-#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
-    addKey((Qt::Key) seq[0]);
-#else
     addKey(seq[0].key());
-#endif
 }
 
 void UKeySequence::addKey(Qt::Key key)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,9 +26,6 @@ int main(int argc, char* argv[]) {
   Q_INIT_RESOURCE(res_icons);
   Q_INIT_RESOURCE(res_migrations);
 
-#if (QT_VERSION_MAJOR < 6)
-  QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
   QCoreApplication::setApplicationName("ashirt");
 
 #ifdef Q_OS_WIN
@@ -65,9 +62,6 @@ int main(int argc, char* argv[]) {
 
   int rtn;
   try {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    qRegisterMetaTypeStreamOperators<model::Tag>("Tag");
-#endif
     QApplication app(argc, argv);
     qRegisterMetaType<model::Tag>();
 


### PR DESCRIPTION
Based on https://github.com/theparanoids/ashirt/pull/141
 - Drop Qt5
 - CI Now build into "build" directory (Remove warning about building in src dir)